### PR TITLE
Fix typos in using-shell-options-optional.adoc

### DIFF
--- a/spring-shell-docs/src/main/asciidoc/using-shell-options-optional.adoc
+++ b/spring-shell-docs/src/main/asciidoc/using-shell-options-optional.adoc
@@ -2,7 +2,7 @@
 === Optional Value
 ifndef::snippets[:snippets: ../../test/java/org/springframework/shell/docs]
 
-An option is either required or not and, generally speaking, how it behavesit depends on
+An option is either required or not and, generally speaking, how it behaves depends on
 a command target:
 
 ====
@@ -13,7 +13,7 @@ include::{snippets}/OptionSnippets.java[tag=option-registration-optional]
 ====
 
 In the annotation model, there is no direct way to define if argument is
-optional. Instead, it is instructed to be `NULL`.:
+optional. Instead, it is instructed to be `NULL`:
 
 ====
 [source, java, indent=0]


### PR DESCRIPTION
Fix small typos in _using-shell-options-optional.adoc_